### PR TITLE
Rename this plugin to "view-serviceaccount-kubeconfig"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/view-kubeconfig
+/view-serviceaccount-kubeconfig
 /_out
 /_dist

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ $(shell mkdir -p _dist)
 
 .PHONY: build
 build:
-		go build -o view-kubeconfig .
+		go build -o view-serviceaccount-kubeconfig .
 
 .PHONY: cross
-build-cross: $(OUT_DIR)/linux-amd64/view-kubeconfig $(OUT_DIR)/darwin-amd64/view-kubeconfig
+build-cross: $(OUT_DIR)/linux-amd64/view-serviceaccount-kubeconfig $(OUT_DIR)/darwin-amd64/view-serviceaccount-kubeconfig
 
 .PHONY: dist
-dist: $(DIST_DIR)/view-kubeconfig-linux-amd64.zip $(DIST_DIR)/view-kubeconfig-darwin-amd64.zip
+dist: $(DIST_DIR)/view-serviceaccount-kubeconfig-linux-amd64.zip $(DIST_DIR)/view-serviceaccount-kubeconfig-darwin-amd64.zip
 
 .PHONY: checksum
 checksum:
@@ -20,17 +20,18 @@ checksum:
 
 .PHONY: clean
 clean:
-		rm -rf $(OUT_DIR) $(DIST_DIR) view-kubeconfig
+		rm -rf $(OUT_DIR) $(DIST_DIR) view-serviceaccount-kubeconfig
 
-$(OUT_DIR)/%-amd64/view-kubeconfig:
+$(OUT_DIR)/%-amd64/view-serviceaccount-kubeconfig:
 		GOOS=$* GOARCH=amd64 go build -o $@ .
 
-$(DIST_DIR)/view-kubeconfig-%-amd64.zip: $(OUT_DIR)/%-amd64/view-kubeconfig
+$(DIST_DIR)/view-serviceaccount-kubeconfig-%-amd64.zip: $(OUT_DIR)/%-amd64/view-serviceaccount-kubeconfig
 		( \
 			cd $(OUT_DIR)/$*-amd64/ && \
 			cp ../../version.txt . && \
 			cp ../../LICENSE . && \
 			cp ../../README.md . && \
 			cp ../../plugin.yaml . && \
+			cp -r ../../view-sa-kubeconfig . && \
 			zip -r ../../$@ * \
 		)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# kubectl plugin view-kubeconfig SERVICEACCOUNT
+# kubectl plugin view-serviceaccount-kubeconfig SERVICEACCOUNT
 
 kubectl plugin that show a kubeconfig to access the apiserver with a specified serviceaccount.
 
 ```
-$ kubectl plugin view-kubeconfig -h
+$ kubectl plugin view-serviceaccount-kubeconfig -h
 Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
+
+You can also use "view-sa-kubeconfig" as alias for this plugin.
 
 Examples:
   # Show a kubeconfig setting of serviceaccount/default
-  kubectl plugin view-kubeconfig default
+  kubectl plugin view-serviceaccount-kubeconfig default
 
 Usage:
-  kubectl plugin view-kubeconfig [options]
+  kubectl plugin view-serviceaccount-kubeconfig [flags] [options]
 
 Use "kubectl options" for a list of global command-line options (applies to all commands).
 ```
@@ -20,20 +22,15 @@ Use "kubectl options" for a list of global command-line options (applies to all 
 
 If you are on macOS, you can install with homebrew:
 ```
-$ brew tap superbrothers/kubectl-view-kubeconfig-plugin
-$ brew install kubectl-view-kubeconfig-plugin
+$ brew tap superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
+$ brew install kubectl-view-serviceaccount-kubeconfig-plugin
 ```
 
 If you are on Linux, you can install with the following steps:
 ```
-$ curl -sLO https://github.com/superbrothers/kubectl-view-kubeconfig-plugin/releases/download/$(curl -sL https://raw.githubusercontent.com/superbrothers/kubectl-view-kubeconfig-plugin/master/version.txt)/view-kubeconfig-linux-amd64.zip
-$ mkdir -p ~/.kube/plugins/view-kubeconfig
-$ unzip view-kubeconfig-linux-amd64.zip -d ~/.kube/plugins/view-kubeconfig
-Archive:  view-kubeconfig-linux-amd64.zip
-  inflating: ~/.kube/plugins/view-kubeconfig/LICENSE
-  inflating: ~/.kube/plugins/view-kubeconfig/README.md
-  inflating: ~/.kube/plugins/view-kubeconfig/plugin.yaml
-  inflating: ~/.kube/plugins/view-kubeconfig/view-kubeconfig
+$ curl -sLO https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/$(curl -sL https://raw.githubusercontent.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/master/version.txt)/view-serviceaccount-kubeconfig-linux-amd64.zip
+$ mkdir -p ~/.kube/plugins/view-serviceaccount-kubeconfig
+$ unzip view-serviceaccount-kubeconfig-linux-amd64.zip -d ~/.kube/plugins/view-serviceaccount-kubeconfig
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func init() {
 
 func main() {
 	if len(os.Args) < 2 {
-		log.Fatalf("Usage: kubectl plugin view-kubeconfig SERVICEACCOUNT")
+		log.Fatalf("Usage: kubectl plugin view-serviceaccount-kubeconfig SERVICEACCOUNT")
 	}
 
 	serviceaccountName := os.Args[1]

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,10 @@
-name: "view-kubeconfig"
+name: "view-serviceaccount-kubeconfig"
 shortDesc: "Show a kubeconfig setting to access the apiserver with a specified serviceaccount."
-example: "# Show a kubeconfig setting of serviceaccount/default\nkubectl plugin view-kubeconfig default"
-command: "./view-kubeconfig"
+longDesc: |
+  Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
+
+  You can also use "view-sa-kubeconfig" as alias for this plugin.
+example: |
+  # Show a kubeconfig setting of serviceaccount/default
+  kubectl plugin view-serviceaccount-kubeconfig default
+command: "./view-serviceaccount-kubeconfig"

--- a/view-sa-kubeconfig/plugin.yaml
+++ b/view-sa-kubeconfig/plugin.yaml
@@ -1,0 +1,8 @@
+name: "view-sa-kubeconfig"
+shortDesc: "An alias for view-serviceaccount-kubeconfig."
+longDesc: |
+  Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
+
+  This command is an alias for view-serviceaccount-kubeconfig.
+  See 'kubectl plugin view-serviceaccount-kubeconfig -h'.
+command: "../view-serviceaccount-kubeconfig"


### PR DESCRIPTION
This PR rename this plugin to "view-serviceaccount-kubeconfig". The new plugin name is easier to understand this plugin what to do from name.