### PR TITLE
Add --output flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Examples:
   
   # Show a kubeconfig setting of serviceaccount/bot in namespace/kube-system
   kubectl view-serviceaccount-kubeconfig bot -n kube-system
+
+  # Show a kubeconfig setting of serviceaccount/default in JSON format
+  kubectl view-serviceaccount-kubeconfig default -o json
 ```
 
 ## Try the plugin


### PR DESCRIPTION
`--output` flag allows you to specify the output format of kubeconfig data (One of yaml|json. defaults to yaml").

/close #20 